### PR TITLE
Allow input device address to contain a port number

### DIFF
--- a/vrClusterConfig/vrClusterConfig/AppRunner/AppRunner.cs
+++ b/vrClusterConfig/vrClusterConfig/AppRunner/AppRunner.cs
@@ -570,10 +570,13 @@ namespace vrClusterConfig
             {
                 if (ccType == ClusterCommandType.Run)
                 {
-                    cl = " uvr_node=" + node.id + cmd;
-
+                    // add node specific command line arguments
+                    Viewport vp = node.viewport;
+                    cl = string.Format(" uvr_node={0} WinX={1} WinY={2} ResX={3} ResY={4} {5}",
+                        node.id, vp.x, vp.y, vp.width, vp.height, cmd);
                 }
-                string clusterCmd = commandCmd +cl;
+
+                string clusterCmd = commandCmd + cl;
                 SendDaemonCommand(node.address, clusterCmd);
             }
         }

--- a/vrClusterConfig/vrClusterConfig/MainWindow.xaml.cs
+++ b/vrClusterConfig/vrClusterConfig/MainWindow.xaml.cs
@@ -345,15 +345,23 @@ namespace vrClusterConfig
         {
             if (type != null)
             {
-                if (type == "tracker")
+                InputType currentType = (InputType)System.Enum.Parse(typeof(InputType), type);
+
+                switch(currentType)
                 {
+                case InputType.tracker:
                     currentConfig.inputs.Add(new TrackerInput { id = "TrackerInputId", address = "TrackerInputName@127.0.0.1", locationX = "0", locationY = "0", locationZ = "0", rotationP = "0", rotationR = "0", rotationY = "0", front = "X", right = "Y", up = "-Z" });
+                    break;
+
+                case InputType.analog:
+                    currentConfig.inputs.Add(new AnalogInput("InputId", "InputName@127.0.0.1"));
+                    break;
+
+                case InputType.buttons:
+                    currentConfig.inputs.Add(new ButtonsInput("InputId", "InputName@127.0.0.1"));
+                    break;
                 }
-                else
-                {
-                    InputType currentType = (InputType)System.Enum.Parse(typeof(InputType), type);
-                    currentConfig.inputs.Add(new BaseInput { id = "InputId", type = currentType, address = "InputName@127.0.0.1" });
-                }
+
                 currentConfig.selectedInput = currentConfig.inputs.LastOrDefault();
                 RefreshUiControls();
                 //inputsListBox.Items.Refresh();

--- a/vrClusterConfig/vrClusterConfig/ValidationRules.cs
+++ b/vrClusterConfig/vrClusterConfig/ValidationRules.cs
@@ -55,5 +55,9 @@ namespace vrClusterConfig
             return Regex.IsMatch(value, "^\\w*@[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$");
         }
 
+        public static bool IsAddressPort(string value)
+        {
+            return Regex.IsMatch(value, "^\\w*@[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}(?::[0-9]{1,5})?$");
+        }
     }
 }

--- a/vrClusterConfig/vrClusterConfig/configData/BaseInput.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/BaseInput.cs
@@ -35,7 +35,7 @@ namespace vrClusterConfig
         }
 
         //Implementation IDataErrorInfo methods for validation
-        public string this[string columnName]
+        public virtual string this[string columnName]
         {
             get
             {
@@ -60,7 +60,7 @@ namespace vrClusterConfig
                 return error;
             }
         }
-        public string Error
+        public virtual string Error
         {
             get { throw new NotImplementedException(); }
         }
@@ -72,9 +72,8 @@ namespace vrClusterConfig
             {
                 AppLogger.Add("ERROR! Errors in Input [" + id + "]");
                 string a = this[validationName];
-               
             }
-            
+
             return isValid;
         }
 

--- a/vrClusterConfig/vrClusterConfig/configData/BaseInput.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/BaseInput.cs
@@ -50,9 +50,9 @@ namespace vrClusterConfig
                 }
                 if (columnName == "address" || columnName == validationName)
                 {
-                    if (!ValidationRules.IsAddress(address))
+                    if (!ValidationRules.IsAddressPort(address))
                     {
-                        error = "Input Address in format InputName@127.0.0.1";
+                        error = "Input Address must be in format InputName@127.0.0.1 or InputName@127.0.0.1:1234";
                         AppLogger.Add("ERROR! " + error);
                     }
                 }
@@ -67,7 +67,7 @@ namespace vrClusterConfig
 
         public override bool Validate()
         {
-            bool isValid = ValidationRules.IsName(id) && ValidationRules.IsAddress(address);
+            bool isValid = ValidationRules.IsName(id) && ValidationRules.IsAddressPort(address);
             if (!isValid)
             {
                 AppLogger.Add("ERROR! Errors in Input [" + id + "]");

--- a/vrClusterConfig/vrClusterConfig/configData/ButtonsInput.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/ButtonsInput.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,10 +6,10 @@ using System.Threading.Tasks;
 
 namespace vrClusterConfig
 {
-    class AnalogInput : BaseInput
+    class ButtonsInput : BaseInput
     {
-        public AnalogInput(string _id, string _address)
-            : base(_id, InputType.analog, _address)
+        public ButtonsInput(string _id, string _address)
+            : base(_id, InputType.buttons, _address)
         {
         }
     }

--- a/vrClusterConfig/vrClusterConfig/configData/Config.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/Config.cs
@@ -471,7 +471,7 @@ namespace vrClusterConfig
         public void InputsParse(string line)
         {
             string id = GetRegEx("id").Match(line).Value;
-            string address = GetRegAddr("addr").Match(line).Value;
+            string address = GetRegAddrPort("addr").Match(line).Value;
             string _type = GetRegEx("type").Match(line).Value;
             InputType type = (InputType)Enum.Parse(typeof(InputType), _type, true);
 
@@ -680,6 +680,12 @@ namespace vrClusterConfig
         Regex GetRegAddr(string key)
         {
             Regex reg = new Regex("(?<=" + key + "=)(\\w*)@((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))(?=\\s|$)");
+            return reg;
+        }
+
+        Regex GetRegAddrPort(string key)
+        {
+            Regex reg = new Regex("(?<=" + key + "=)(\\w*)@((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(?::[0-9]{1,5})?)(?=\\s|$)");
             return reg;
         }
 

--- a/vrClusterConfig/vrClusterConfig/configData/Config.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/Config.cs
@@ -474,8 +474,10 @@ namespace vrClusterConfig
             string address = GetRegAddr("addr").Match(line).Value;
             string _type = GetRegEx("type").Match(line).Value;
             InputType type = (InputType)Enum.Parse(typeof(InputType), _type, true);
-            if (type == InputType.tracker)
+
+            switch(type)
             {
+            case InputType.tracker:
                 string loc = GetRegComplex("loc").Match(line).Value;
                 string locX = GetRegProp("X").Match(loc).Value;
                 string locY = GetRegProp("Y").Match(loc).Value;
@@ -488,10 +490,15 @@ namespace vrClusterConfig
                 string right = GetRegEx("right").Match(line).Value;
                 string up = GetRegEx("up").Match(line).Value;
                 inputs.Add(new TrackerInput(id, address, locX, locY, locZ, rotP, rotY, rotR, front, right, up));
-            }
-            else
-            {
-                inputs.Add(new BaseInput(id, type, address));
+                break;
+
+            case InputType.analog:
+                inputs.Add(new AnalogInput(id, address));
+                break;
+
+            case InputType.buttons:
+                inputs.Add(new ButtonsInput(id, address));
+                break;
             }
         }
 

--- a/vrClusterConfig/vrClusterConfig/configData/TrackerInput.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/TrackerInput.cs
@@ -52,27 +52,11 @@ namespace vrClusterConfig
         }
 
         //Implementation IDataErrorInfo methods for validation
-        public string this[string columnName]
+        public override string this[string columnName]
         {
             get
             {
-                string error = String.Empty;
-                if (columnName == "id" || columnName == validationName)
-                {
-                    if (!ValidationRules.IsName(id))
-                    {
-                        error = "Input ID should contain only letters, numbers and _";
-                        AppLogger.Add("ERROR! " + error);
-                    }
-                }
-                if (columnName == "address" || columnName == validationName)
-                {
-                    if (!ValidationRules.IsAddress(address))
-                    {
-                        error = "Input Address in format InputName@127.0.0.1";
-                        AppLogger.Add("ERROR! " + error);
-                    }
-                }
+                string error = base[columnName];
                 if (columnName == "locationX" || columnName == validationName)
                 {
                     if (!ValidationRules.IsFloat(locationX.ToString()))
@@ -126,21 +110,16 @@ namespace vrClusterConfig
                 return error;
             }
         }
-        public string Error
-        {
-            get { throw new NotImplementedException(); }
-        }
 
-        public new bool Validate()
+        public override bool Validate()
         {
-            bool isValid = ValidationRules.IsName(id) && ValidationRules.IsAddress(address) && ValidationRules.IsFloat(locationX.ToString()) 
+            bool isValid = base.Validate() && ValidationRules.IsFloat(locationX.ToString()) 
                 && ValidationRules.IsFloat(locationY.ToString()) && ValidationRules.IsFloat(locationZ.ToString()) && ValidationRules.IsFloat(rotationP.ToString()) 
                 && ValidationRules.IsFloat(rotationY.ToString()) && ValidationRules.IsFloat(rotationR.ToString());
             if (!isValid)
             {
-                AppLogger.Add("ERROR! Errors in Input [" + id + "]");
+                AppLogger.Add("ERROR! Errors in Tracker Input [" + id + "]");
                 string a = this[validationName];
-
             }
 
             return isValid;

--- a/vrClusterConfig/vrClusterConfig/vrClusterConfig.csproj
+++ b/vrClusterConfig/vrClusterConfig/vrClusterConfig.csproj
@@ -100,6 +100,7 @@
     </ApplicationDefinition>
     <Compile Include="AppLogger.cs" />
     <Compile Include="AppRunner\ActiveNode.cs" />
+    <Compile Include="ConfigData\ButtonsInput.cs" />
     <Compile Include="ValueConverters\BooleanInverterConverter.cs" />
     <Compile Include="ValueConverters\BoolToHorizontalBorderConverter.cs" />
     <Compile Include="ValueConverters\BoolToVerticalBorderConverter.cs" />


### PR DESCRIPTION
This short series adds the ability to configure the port number at which to connect to a VRPN server. It is sometimes useful to run multiple VRPN servers on the same machine, where they then need to use distinct ports. This happens for example when using tracking software that has built-in support for VRPN together with additional devices that the tracking software does not handle (e.g. buttons/analogs from a game controller).