### PR TITLE
Add game window position/size to viewport configuration

### DIFF
--- a/vrClusterConfig/vrClusterConfig/MainWindow.xaml
+++ b/vrClusterConfig/vrClusterConfig/MainWindow.xaml
@@ -950,6 +950,10 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Label Grid.Column="0" Grid.Row="0" Content="Viewport ID" />
                             <TextBox x:Name="viewportIdTb" Grid.Column="1" Grid.Row="0" Style="{DynamicResource NameTB}" Text="{Binding selectedViewport.id, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" AutomationProperties.HelpText="help text" ToolTip="Viewport ID, you can use letters, numbers and _" />
@@ -961,6 +965,14 @@
                             <TextBox x:Name="viewportWidthTb" Grid.Column="1" Grid.Row="4" Style="{DynamicResource SizeTB}" Text="{Binding selectedViewport.width, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" ToolTip="Width of viewport in pixels" />
                             <Label Grid.Column="0" Grid.Row="5" Content="Height"/>
                             <TextBox x:Name="viewportHeightTb" Grid.Column="1" Grid.Row="5" Style="{DynamicResource SizeTB}" Text="{Binding selectedViewport.height, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" ToolTip="Height of viewport in pixels" />
+                            <Label Grid.Column="0" Grid.Row="6" Content="Window X"/>
+                            <TextBox x:Name="viewportWinXTb" Grid.Column="1" Grid.Row="6" Style="{DynamicResource SizeTB}" Text="{Binding selectedViewport.winX, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" ToolTip="X coordinate of application window in pixels" />
+                            <Label Grid.Column="0" Grid.Row="7" Content="Window Z"/>
+                            <TextBox x:Name="viewportWinYTb" Grid.Column="1" Grid.Row="7" Style="{DynamicResource SizeTB}" Text="{Binding selectedViewport.winY, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" ToolTip="Y coordinate of application window in pixels" />
+                            <Label Grid.Column="0" Grid.Row="8" Content="Window Width"/>
+                            <TextBox x:Name="viewportWinWidthTb" Grid.Column="1" Grid.Row="8" Style="{DynamicResource SizeTB}" Text="{Binding selectedViewport.winWidth, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" ToolTip="Width of application window in pixels" />
+                            <Label Grid.Column="0" Grid.Row="9" Content="Window Height"/>
+                            <TextBox x:Name="viewportWinHeightTb" Grid.Column="1" Grid.Row="9" Style="{DynamicResource SizeTB}" Text="{Binding selectedViewport.winHeight, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" ToolTip="Height of application window in pixels" />
                         </Grid>
                         <Grid Grid.Row="2">
                             <CheckBox x:Name="isVerticalFlip" Content="Vertical Flip" HorizontalAlignment="Left" Template="{DynamicResource CustomCheckBoxControlTemplate}" IsChecked="{Binding selectedViewport.verticalFlip}" />
@@ -990,14 +1002,14 @@
                            
                             <Canvas Canvas.Left="{Binding mainScreenOffsetX}" Canvas.Top="{Binding mainScreenOffsetY}" Width="{Binding mainScreenWidth}" Height="{Binding mainScreenHeight}" Background="#FF0FBDBD" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,0" >
 
-                                <Border x:Name="previewViewport" TextBlock.TextAlignment="Center" Background="#7FB15656" Width="{Binding selectedViewport.width}" Height="{Binding selectedViewport.height}" Canvas.Left="{Binding selectedViewport.x}" Canvas.Top="{Binding selectedViewport.y}" SnapsToDevicePixels="True" >
+                                <Border x:Name="previewViewport" TextBlock.TextAlignment="Center" Background="#7FB15656" Width="{Binding selectedViewport.winWidth}" Height="{Binding selectedViewport.winHeight}" Canvas.Left="{Binding selectedViewport.winX}" Canvas.Top="{Binding selectedViewport.winY}" SnapsToDevicePixels="True" >
                                     <Grid>
                                         <Viewbox Stretch="Uniform" MaxHeight="{Binding ElementName=viewportCanvas, Path=DataContext.textZone }" HorizontalAlignment="{Binding selectedViewport.horizontalFlip, Converter={StaticResource InvertBoolToHorizontalConverter}}" VerticalAlignment="{Binding selectedViewport.verticalFlip, Converter={StaticResource InvertBoolToVerticalConverter}}"  OpacityMask="Black" Opacity="0.5" >
                                             <TextBlock  HorizontalAlignment="Center" VerticalAlignment="Center"  >
                                                 <TextBlock.Text>
                                                     <MultiBinding StringFormat="({0},{1})">
-                                                        <Binding Path="selectedViewport.x"/>
-                                                        <Binding Path="selectedViewport.y"/>
+                                                        <Binding Path="selectedViewport.winX"/>
+                                                        <Binding Path="selectedViewport.winY"/>
                                                     </MultiBinding>
                                                 </TextBlock.Text>
                                             </TextBlock>
@@ -1009,8 +1021,8 @@
                                             <TextBlock  HorizontalAlignment="Center" VerticalAlignment="Center"  >
                                                 <TextBlock.Text>
                                                     <MultiBinding StringFormat="({0},{1})">
-                                                        <Binding Path="selectedViewport.width"/>
-                                                        <Binding Path="selectedViewport.height"/>
+                                                        <Binding Path="selectedViewport.winWidth"/>
+                                                        <Binding Path="selectedViewport.winHeight"/>
                                                     </MultiBinding>
                                                 </TextBlock.Text>
                                             </TextBlock>

--- a/vrClusterConfig/vrClusterConfig/configData/Config.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/Config.cs
@@ -565,10 +565,18 @@ namespace vrClusterConfig
         public void ViewportParse(string line)
         {
             string id = GetRegEx("id").Match(line).Value;
-            string x = GetRegEx("x").Match(line).Value;
-            string y = GetRegEx("y").Match(line).Value;
-            string width = GetRegEx("width").Match(line).Value;
-            string height = GetRegEx("height").Match(line).Value;
+            string loc = GetRegComplex("loc").Match(line).Value;
+            string locX = GetRegProp("X").Match(loc).Value;
+            string locY = GetRegProp("Y").Match(loc).Value;
+            string size = GetRegComplex("size").Match(line).Value;
+            string sizeX = GetRegProp("X").Match(size).Value;
+            string sizeY = GetRegProp("Y").Match(size).Value;
+            string winLoc = GetRegComplex("win_loc").Match(line).Value;
+            string winLocX = GetRegProp("X").Match(winLoc).Value;
+            string winLocY = GetRegProp("Y").Match(winLoc).Value;
+            string winSize = GetRegComplex("win_size").Match(line).Value;
+            string winSizeX = GetRegProp("X").Match(winSize).Value;
+            string winSizeY = GetRegProp("Y").Match(winSize).Value;
             string _flip_h = GetRegEx("flip_h").Match(line).Value;
             string _flip_v = GetRegEx("flip_v").Match(line).Value;
             bool flip_h = false;
@@ -581,7 +589,7 @@ namespace vrClusterConfig
             {
                 flip_v = true;
             }
-            viewports.Add(new Viewport(id, x, y, width, height, flip_h, flip_v));
+            viewports.Add(new Viewport(id, locX, locY, sizeX, sizeY, winLocX, winLocY, winSizeX, winSizeY, flip_h, flip_v));
         }
 
         //Camera Parser

--- a/vrClusterConfig/vrClusterConfig/configData/Viewport.cs
+++ b/vrClusterConfig/vrClusterConfig/configData/Viewport.cs
@@ -14,6 +14,10 @@ namespace vrClusterConfig
         public string y { get; set; }
         public string width { get; set; }
         public string height { get; set; }
+        public string winX { get; set; }
+        public string winY { get; set; }
+        public string winWidth { get; set; }
+        public string winHeight { get; set; }
         public bool horizontalFlip { get; set; }
         public bool verticalFlip { get; set; }
 
@@ -24,17 +28,25 @@ namespace vrClusterConfig
             y = "0";
             width = "0";
             height = "0";
+            winX = "0";
+            winY = "0";
+            winWidth = "0";
+            winHeight = "0";
             horizontalFlip = false;
             verticalFlip = false;
         }
 
-        public Viewport(string _id, string _x, string _y, string _width, string _height, bool _horizontalFlip, bool _verticalFlip)
+        public Viewport(string _id, string _x, string _y, string _width, string _height, string _winX, string _winY, string _winWidth, string _winHeight, bool _horizontalFlip, bool _verticalFlip)
         {
             id = _id;
             x = _x;
             y = _y;
             width = _width;
             height = _height;
+            winX = _winX;
+            winY = _winY;
+            winWidth = _winWidth;
+            winHeight = _winHeight;
             horizontalFlip = _horizontalFlip;
             verticalFlip = _verticalFlip;
         }
@@ -77,13 +89,44 @@ namespace vrClusterConfig
                         AppLogger.Add("ERROR! " + error);
                     }
                 }
-
                 if (columnName == "height" || columnName == validationName)
                 {
-                    if (!ValidationRules.IsInt(height.ToString()) || Convert.ToInt32(height) <0)
+                    if (!ValidationRules.IsInt(height.ToString()) || Convert.ToInt32(height) < 0)
                     {
                         error = "Height should be an integer";
                         AppLogger.Add("ERROR! " + error);
+                    }
+                }
+                if (columnName == "winX" || columnName == validationName)
+                {
+                    if (!ValidationRules.IsInt(winX.ToString()))
+                    {
+                        error = "winX should be an integer";
+                        AppLogger.Add("Error! " + error);
+                    }
+                }
+                if (columnName == "winY" || columnName == validationName)
+                {
+                    if (!ValidationRules.IsInt(winY.ToString()))
+                    {
+                        error = "winY should be an integer";
+                        AppLogger.Add("Error! " + error);
+                    }
+                }
+                if (columnName == "winWidth" || columnName == validationName)
+                {
+                    if (!ValidationRules.IsInt(winWidth.ToString()) || Convert.ToInt32(winWidth) < 0)
+                    {
+                        error = "winWidth should be a integer (>= 0)";
+                        AppLogger.Add("Error! " + error);
+                    }
+                }
+                if (columnName == "winHeight" || columnName == validationName)
+                {
+                    if (!ValidationRules.IsInt(winHeight.ToString()) || Convert.ToInt32(winHeight) < 0)
+                    {
+                        error = "winHeight should be a integer (>= 0)";
+                        AppLogger.Add("Error! " + error);
                     }
                 }
                 //switch (columnName)
@@ -134,7 +177,10 @@ namespace vrClusterConfig
         public override bool Validate()
         {
             bool isValid = ValidationRules.IsName(id) && ValidationRules.IsInt(x.ToString()) && ValidationRules.IsInt(y.ToString()) 
-                && (ValidationRules.IsInt(width.ToString()) || Convert.ToInt32(width) > 0) && (ValidationRules.IsInt(height.ToString()) || Convert.ToInt32(height) > 0);
+                && (ValidationRules.IsInt(width.ToString()) || Convert.ToInt32(width) > 0) && (ValidationRules.IsInt(height.ToString()) || Convert.ToInt32(height) > 0)
+                && ValidationRules.IsInt(winX) && ValidationRules.IsInt(winY)
+                && (ValidationRules.IsInt(winWidth) && Convert.ToInt32(winWidth) >= 0)
+                && (ValidationRules.IsInt(winHeight) && Convert.ToInt32(winHeight) >= 0);
             if (!isValid)
             {
                 AppLogger.Add("ERROR! Errors in Viewport [" + id + "]");
@@ -148,7 +194,9 @@ namespace vrClusterConfig
         public override string CreateCfg()
         {
             string stringCfg = "[viewport] ";
-            stringCfg = string.Concat(stringCfg, "id=", id, " x=", x, " y=", y, " width=", width, " height=", height, " flip_h=", horizontalFlip.ToString(), "flip_v=", verticalFlip, "\n");
+            stringCfg = string.Concat(stringCfg, "id=", id, " loc=\"X=", x, ",Y=", y, "\" size=\"X=", width, ",Y=", height,
+                "\" win_loc=\"X=", winX, ",Y=", winY, "\" win_size=\"X=", winWidth, ",Y=", winHeight,
+                "\" flip_h=", horizontalFlip.ToString(), " flip_v=", verticalFlip, "\n");
 
             return stringCfg;
         }


### PR DESCRIPTION
On multi display systems it is useful to be able to position the game
window on specific displays. Add new config variables in order to not
mix the window positioning with the viewport (i.e. the part of the
window being rendered to).
This does change the configuration format for viewports:
x=N, y=M -> loc="X=N,Y=M"
width=N, height=M -> size="X=N,Y=M"